### PR TITLE
Add ability to embed Forms in Blocks

### DIFF
--- a/src/Controller/ContentBlockController.php
+++ b/src/Controller/ContentBlockController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace CyberDuck\BlockPage\Controller;
+
+use CyberDuck\BlockPage\Model\ContentBlock;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+
+class ContentBlockController extends Controller
+{
+    /**
+     * @var ContentBlock $content_block
+     */
+    protected $content_block;
+
+    /**
+     * Constructor
+     *
+     * @param ContentBlock $content_block
+     */
+    public function __construct(ContentBlock $content_block)
+    {
+        $this->content_block = $content_block;
+
+        parent::__construct();
+
+        $this->setRequest(Controller::curr()->getRequest());
+    }
+
+    /**
+     * Get current content block
+     *
+     * @return ContentBlock
+     */
+    public function getContentBlock()
+    {
+        return $this->content_block;
+    }
+
+    /**
+     * Get link string prepared for form action
+     *
+     * @param string $form Form name
+     *
+     * @return string Form action link
+     */
+    public function getFormActionLink($form = 'Form')
+    {
+        $controller = Controller::curr();
+
+        return Controller::join_links(
+            $controller->Link(),
+            'block',
+            $this->getContentBlock()->ID,
+            $form
+        );
+    }
+
+    /**
+     * Get Link with Content Block Anchor
+     * Usable for forms redirections to Content Block on page
+     *
+     * @param string $action Action name
+     *
+     * @return string
+     */
+    public function Link($action = null)
+    {
+        $page = Director::get_current_page();
+        $controller = Controller::curr();
+
+        if ($controller && ! ($controller instanceof self)) {
+            return Controller::join_links(
+                $controller->Link($action),
+                '#block-'.$this->content_block->ID
+            );
+        }
+        if ($page && ! ($page instanceof self)) {
+            return Controller::join_links(
+                $page->Link($action),
+                '#block-'.$this->content_block->ID
+            );
+        }
+    }
+}

--- a/src/Extension/ContentBlockControllerExtension.php
+++ b/src/Extension/ContentBlockControllerExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CyberDuck\BlockPage\Extension;
+
+use CyberDuck\BlockPage\Model\ContentBlock;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
+
+class ContentBlockControllerExtension extends Extension
+{
+    private static $allowed_actions = [
+        'handleContentBlock',
+    ];
+
+    /**
+     * Handles Content Block Controller request
+     *
+     * @param  HttpRequest $request
+     *
+     * @return Controller Current Content Block Controller
+     */
+    public function handleContentBlock($request)
+    {
+        $id = $request->param('ID');
+        $action = $request->param('OtherID');
+        $block = ContentBlock::get()->byId($id);
+        $blockController = $block->ClassName.'Controller';
+
+        if (class_exists($blockController)) {
+            $blockController = Injector::inst()->get($blockController, true, [$block]);
+            $blockController->doInit();
+
+            if (! $blockController->checkAccessAction($action)) {
+                // TODO: raise user Exception
+            }
+
+            return $blockController;
+        }
+
+        return Controller::curr();
+    }
+}

--- a/src/Model/ContentBlock.php
+++ b/src/Model/ContentBlock.php
@@ -48,8 +48,8 @@ class ContentBlock extends DataObject implements PermissionProvider
 
     private static $summary_fields = [
         'Thumbnail'   => '',
-        'ID'          => 'ID',
-        'ClassName'   => 'ClassName',
+        'ID'          => 'ID',        
+        'BlockType'   => 'Content type',
         'Title'       => 'Title',
         'Pages.Count' => 'Pages'
     ];
@@ -94,6 +94,11 @@ class ContentBlock extends DataObject implements PermissionProvider
         return array_pop($path);
     }
 
+    public function getBlockType()
+    {
+        return $this->owner->ClassName::config()->get('title');
+    }
+    
     private function getCMSSelectionFields(FieldList $fields)
     {
         $fields->removeByName('Root');


### PR DESCRIPTION
Easily and uniformly embed custom Forms in Blocks.

Usage:

- Add extension in your project _config/config.yml
```
SilverStripe\CMS\Controllers\ContentController: # or extend your Page class
  extensions:
    - CyberDuck\BlockPage\Extension\ContentBlockControllerExtension
  url_handlers:
    'block/$ID!': 'handleContentBlock'
```

- Create your new Form class (ie. NewsletterBlockForm)

- Create new controller class for your Block and name it {YourBlockClassName}Controller (ie. NewsletterBlockController) 
```
use CyberDuck\BlockPage\Controller\ContentBlockController;

class NewsletterBlockController extends ContentBlockController
{
    private static $allowed_actions = [
        'NewsletterForm',
    ];

    public function NewsletterForm()
    {
        return NewsletterBlockForm::create($this)
            ->setFormAction($this->getFormActionLink('NewsletterForm'));
    }

    protected function init()
    {
        parent::init();
    }
}
```

- Add function in your Block class returning your new Form
```
    public function NewsletterForm()
    {
        $controller = NewsletterBlockController::create($this)
            ->setRequest(Controller::curr()->getRequest());

        return $controller->NewsletterForm();
    }
```